### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 # .github/workflows/ci.yml
 
 name: Continuous Integration
+permissions:
+  contents: read
 
 # This workflow runs on every push or pull request to the 'main' branch
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/gauciv/awscommunity-day-cebu-2025/security/code-scanning/1](https://github.com/gauciv/awscommunity-day-cebu-2025/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily involves reading repository contents and does not appear to require write permissions. Therefore, we will set `contents: read` as the permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
