### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lock-on-label.yml
+++ b/.github/workflows/lock-on-label.yml
@@ -1,5 +1,7 @@
 # This is the name of the GitHub Action workflow
 name: Lock Blocked Issues
+permissions:
+  issues: write
 
 # This section defines when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/gauciv/awscommunity-day-cebu-2025/security/code-scanning/2](https://github.com/gauciv/awscommunity-day-cebu-2025/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow locks and unlocks issues, it requires `issues: write` permission. Other permissions, such as `contents: read`, can be included if necessary for the workflow's operation, but they are not required in this case.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`lock-issue`) to limit permissions to that job only. In this case, adding it at the root level is sufficient and ensures clarity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
